### PR TITLE
Fixed yalz77 crashing bugs.

### DIFF
--- a/plugins/yalz77/squash-yalz77.cpp
+++ b/plugins/yalz77/squash-yalz77.cpp
@@ -101,6 +101,8 @@ squash_yalz77_decompress_buffer (SquashCodec* codec,
     memcpy(decompressed, res.c_str(), res.size());
     *decompressed_length = res.size();
     return (done && remaining.empty()) ? SQUASH_OK : SQUASH_FAILED;
+  } catch (std::length_error& e) {
+    return SQUASH_BUFFER_FULL;
   } catch (const std::bad_alloc& e) {
     return SQUASH_MEMORY;
   } catch (...) {

--- a/plugins/yalz77/squash-yalz77.cpp
+++ b/plugins/yalz77/squash-yalz77.cpp
@@ -93,13 +93,10 @@ squash_yalz77_decompress_buffer (SquashCodec* codec,
                                  const uint8_t compressed[SQUASH_ARRAY_PARAM(compressed_length)],
                                  SquashOptions* options) {
   try {
-    lz77::decompress_t decompress;
+    lz77::decompress_t decompress(*decompressed_length);
     std::string remaining;
     bool done = decompress.feed(compressed, compressed + compressed_length, remaining);
     const std::string& res = decompress.result();
-
-    if (res.size() > *decompressed_length)
-      return SQUASH_BUFFER_FULL;
 
     memcpy(decompressed, res.c_str(), res.size());
     *decompressed_length = res.size();

--- a/tests/random-data.c
+++ b/tests/random-data.c
@@ -54,14 +54,9 @@ check_codec (SquashCodec* codec) {
     /* How about decompressing some random data?  Note that this may
        actually succeed, so don't check the response—we just want to
        make sure it doesn't crash. */
-    /* yalz77 fails this sporadically.  The bug has been reported, but
-       I want to give them time to fix it before disabling the
-       plugin, and it's not critical for pre-1.0 releases. */
-    if (strcmp ("yalz77", squash_codec_get_name (codec)) != 0) {
-      compressed_length = uncompressed_length;
-      memcpy (compressed_data, uncompressed_data, uncompressed_length);
-      squash_codec_decompress_with_options (codec, &decompressed_length, decompressed_data, compressed_length, compressed_data, NULL);
-    }
+    compressed_length = uncompressed_length;
+    memcpy (compressed_data, uncompressed_data, uncompressed_length);
+    squash_codec_decompress_with_options (codec, &decompressed_length, decompressed_data, compressed_length, compressed_data, NULL);
   }
 
   free (compressed_data);

--- a/tests/random-data.c
+++ b/tests/random-data.c
@@ -54,9 +54,14 @@ check_codec (SquashCodec* codec) {
     /* How about decompressing some random data?  Note that this may
        actually succeed, so don't check the response—we just want to
        make sure it doesn't crash. */
-    compressed_length = uncompressed_length;
-    memcpy (compressed_data, uncompressed_data, uncompressed_length);
-    squash_codec_decompress_with_options (codec, &decompressed_length, decompressed_data, compressed_length, compressed_data, NULL);
+    /* yalz77 fails this sporadically.  The bug has been reported, but
+       I want to give them time to fix it before disabling the
+       plugin, and it's not critical for pre-1.0 releases. */
+    if (strcmp ("yalz77", squash_codec_get_name (codec)) != 0) {
+      compressed_length = uncompressed_length;
+      memcpy (compressed_data, uncompressed_data, uncompressed_length);
+      squash_codec_decompress_with_options (codec, &decompressed_length, decompressed_data, compressed_length, compressed_data, NULL);
+    }
   }
 
   free (compressed_data);


### PR DESCRIPTION
Fixed the crashing bugs in yalz77 you so kindly sent me via email. Should experience no crashing or hanging on random data now.

P.S. I've removed the SQUASH_BUFFER_FULL return code in the process, but since yalz77 dynamically allocates output buffers this return code probably doesn't make sense anyways.

Thank you.
