### PR TITLE
Add BriefLZ plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -80,3 +80,6 @@
 	path = plugins/zlib-ng/zlib-ng
 	url = https://github.com/Dead2/zlib-ng.git
 	branch = develop
+[submodule "plugins/brieflz/brieflz"]
+	path = plugins/brieflz/brieflz
+	url = https://github.com/jibsen/brieflz.git

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,4 +1,5 @@
 set (plugins_available
+  brieflz
   brotli
   bsc
   bzip2

--- a/plugins/brieflz/CMakeLists.txt
+++ b/plugins/brieflz/CMakeLists.txt
@@ -1,7 +1,7 @@
 set (brieflz_sources
   squash-brieflz.c
   brieflz/brieflz.c
-  brieflz/depack.c)
+  brieflz/depacks.c)
 
 squash_plugin_add (brieflz brieflz_sources)
 squash_plugin_add_include_directories (brieflz brieflz)

--- a/plugins/brieflz/CMakeLists.txt
+++ b/plugins/brieflz/CMakeLists.txt
@@ -1,0 +1,7 @@
+set (brieflz_sources
+  squash-brieflz.c
+  brieflz/brieflz.c
+  brieflz/depack.c)
+
+squash_plugin_add (brieflz brieflz_sources)
+squash_plugin_add_include_directories (brieflz brieflz)

--- a/plugins/brieflz/brieflz.md
+++ b/plugins/brieflz/brieflz.md
@@ -1,0 +1,17 @@
+# BriefLZ Plugin #
+
+BriefLZ is a small, fast Lempel-Ziv compression library.
+
+For more information about BriefLZ, see
+https://github.com/jibsen/brieflz
+
+## Codecs ##
+
+- **brieflz** — Raw BriefLZ data.
+
+## License ##
+
+The BriefLZ plugin is licensed under the [MIT
+License](http://opensource.org/licenses/MIT), and BriefLZ
+is licensed under the [zlib
+license](http://opensource.org/licenses/Zlib).

--- a/plugins/brieflz/squash-brieflz.c
+++ b/plugins/brieflz/squash-brieflz.c
@@ -1,0 +1,127 @@
+/* Copyright (c) 2015 The Squash Authors
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Authors:
+ *   Evan Nemerson <evan@nemerson.com>
+ *   Joergen Ibsen
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <errno.h>
+
+#include <squash/squash.h>
+#include <brieflz.h>
+
+#include <stdio.h>
+
+SQUASH_PLUGIN_EXPORT
+SquashStatus squash_plugin_init_codec (SquashCodec* codec, SquashCodecImpl* impl);
+
+static size_t
+squash_brieflz_get_max_compressed_size (SquashCodec* codec, size_t uncompressed_length) {
+  return (size_t) blz_max_packed_size ((unsigned long) uncompressed_length) + 4;
+}
+
+static SquashStatus
+squash_brieflz_decompress_buffer (SquashCodec* codec,
+                                  size_t* decompressed_length,
+                                  uint8_t decompressed[SQUASH_ARRAY_PARAM(*decompressed_length)],
+                                  size_t compressed_length,
+                                  const uint8_t compressed[SQUASH_ARRAY_PARAM(compressed_length)],
+                                  SquashOptions* options) {
+  unsigned long original_size;
+  unsigned long size;
+
+  original_size = (unsigned long) compressed[0]
+               | ((unsigned long) compressed[1] << 8)
+               | ((unsigned long) compressed[2] << 16)
+               | ((unsigned long) compressed[3] << 24);
+
+  if (original_size > *decompressed_length) {
+    return squash_error (SQUASH_BUFFER_FULL);
+  }
+
+  size = blz_depack (compressed + 4, decompressed, original_size);
+
+  if (size != original_size) {
+    return squash_error (SQUASH_FAILED);
+  }
+
+  *decompressed_length = (size_t) size;
+
+  return SQUASH_OK;
+}
+
+static SquashStatus
+squash_brieflz_compress_buffer (SquashCodec* codec,
+                                size_t* compressed_length,
+                                uint8_t compressed[SQUASH_ARRAY_PARAM(*compressed_length)],
+                                size_t uncompressed_length,
+                                const uint8_t uncompressed[SQUASH_ARRAY_PARAM(uncompressed_length)],
+                                SquashOptions* options) {
+  unsigned long size;
+  void *workmem = NULL;
+
+  if ((unsigned long) *compressed_length
+    < squash_brieflz_get_max_compressed_size (codec, uncompressed_length)) {
+    return squash_error (SQUASH_BUFFER_FULL);
+  }
+
+  workmem = malloc (blz_workmem_size ((unsigned long) uncompressed_length));
+
+  if (workmem == NULL) {
+    return squash_error (SQUASH_MEMORY);
+  }
+
+  compressed[0] = (uint8_t) uncompressed_length;
+  compressed[1] = (uint8_t) (uncompressed_length >> 8);
+  compressed[2] = (uint8_t) (uncompressed_length >> 16);
+  compressed[3] = (uint8_t) (uncompressed_length >> 24);
+
+  size = blz_pack (uncompressed, compressed + 4,
+                   (unsigned long) uncompressed_length,
+                   workmem);
+
+  free(workmem);
+
+  *compressed_length = (size_t) size + 4;
+
+  return SQUASH_OK;
+}
+
+SquashStatus
+squash_plugin_init_codec (SquashCodec* codec, SquashCodecImpl* impl) {
+  const char* name = squash_codec_get_name (codec);
+
+  if (strcmp ("brieflz", name) == 0) {
+    impl->get_max_compressed_size = squash_brieflz_get_max_compressed_size;
+    impl->decompress_buffer = squash_brieflz_decompress_buffer;
+    impl->compress_buffer_unsafe = squash_brieflz_compress_buffer;
+  } else {
+    return squash_error (SQUASH_UNABLE_TO_LOAD);
+  }
+
+  return SQUASH_OK;
+}

--- a/plugins/brieflz/squash-brieflz.c
+++ b/plugins/brieflz/squash-brieflz.c
@@ -54,6 +54,10 @@ squash_brieflz_decompress_buffer (SquashCodec* codec,
   unsigned long original_size;
   unsigned long size;
 
+  if (compressed_length < 4) {
+    return squash_error (SQUASH_FAILED);
+  }
+
   original_size = (unsigned long) compressed[0]
                | ((unsigned long) compressed[1] << 8)
                | ((unsigned long) compressed[2] << 16)

--- a/plugins/brieflz/squash-brieflz.c
+++ b/plugins/brieflz/squash-brieflz.c
@@ -44,6 +44,20 @@ squash_brieflz_get_max_compressed_size (SquashCodec* codec, size_t uncompressed_
   return (size_t) blz_max_packed_size ((unsigned long) uncompressed_length) + 4;
 }
 
+static size_t
+squash_brieflz_get_uncompressed_size (SquashCodec* codec,
+                                      size_t compressed_length,
+                                      const uint8_t compressed[SQUASH_ARRAY_PARAM(compressed_length)]) {
+  if (compressed_length < 4) {
+    return 0;
+  }
+
+  return (size_t) compressed[0]
+      | ((size_t) compressed[1] << 8)
+      | ((size_t) compressed[2] << 16)
+      | ((size_t) compressed[3] << 24);
+}
+
 static SquashStatus
 squash_brieflz_decompress_buffer (SquashCodec* codec,
                                   size_t* decompressed_length,
@@ -120,6 +134,7 @@ squash_plugin_init_codec (SquashCodec* codec, SquashCodecImpl* impl) {
   const char* name = squash_codec_get_name (codec);
 
   if (strcmp ("brieflz", name) == 0) {
+    impl->get_uncompressed_size = squash_brieflz_get_uncompressed_size;
     impl->get_max_compressed_size = squash_brieflz_get_max_compressed_size;
     impl->decompress_buffer = squash_brieflz_decompress_buffer;
     impl->compress_buffer_unsafe = squash_brieflz_compress_buffer;

--- a/plugins/brieflz/squash-brieflz.c
+++ b/plugins/brieflz/squash-brieflz.c
@@ -81,7 +81,8 @@ squash_brieflz_decompress_buffer (SquashCodec* codec,
     return squash_error (SQUASH_BUFFER_FULL);
   }
 
-  size = blz_depack (compressed + 4, decompressed, original_size);
+  size = blz_depack_safe (compressed + 4, (unsigned long) compressed_length - 4,
+                          decompressed, original_size);
 
   if (size != original_size) {
     return squash_error (SQUASH_FAILED);

--- a/plugins/brieflz/squash.ini
+++ b/plugins/brieflz/squash.ini
@@ -1,0 +1,3 @@
+license=zlib
+
+[brieflz]


### PR DESCRIPTION
My first attempt at writing a plugin for Squash, so I may have missed something. In particular, while I tested this on Linux, I pushed the changes from Windows, so I hope I got the submodule right.

I copied the interface code from one of the other plugins and made a few changes:

  - BriefLZ requires the decompressed size when decompressing, so I store that as the first four bytes of the compressed data.
  - Allocate and free workmem.
  - Check buffer sizes to pass the unit tests.