### PR TITLE
Working on MSVC support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,9 @@ environment:
 
 configuration: Debug
 
+install: git submodule update --init --recursive
+
 before_build:
-  - git submodule update --init --recursive
   - mkdir build
   - cd build
   - cmake -DCMAKE_BUILD_TYPE=%CONFIGURATION% -G "%GENERATOR%" -DENABLE_GIPFELI=no -DENABLE_BROTLI=no -DENABLE_DENSITY=no -DENABLE_PITHY=no -DENABLE_SNAPPY=no -DENABLE_ZLING=no ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+version: 0.8.0-{build}
+
+environment:
+  matrix:
+  - GENERATOR: Visual Studio 14 2015
+  - GENERATOR: Visual Studio 14 2015 Win64
+
+configuration: Debug
+
+before_build:
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_BUILD_TYPE=%CONFIGURATION% -G "%GENERATOR%" -DENABLE_GIPFELI=no -DENABLE_BROTLI=no -DENABLE_DENSITY=no -DENABLE_PITHY=no -DENABLE_SNAPPY=no -DENABLE_ZLING=no ..
+
+build_script: cmake --build . --config %CONFIGURATION%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
 configuration: Debug
 
 before_build:
+  - git submodule update --init --recursive
   - mkdir build
   - cd build
   - cmake -DCMAKE_BUILD_TYPE=%CONFIGURATION% -G "%GENERATOR%" -DENABLE_GIPFELI=no -DENABLE_BROTLI=no -DENABLE_DENSITY=no -DENABLE_PITHY=no -DENABLE_SNAPPY=no -DENABLE_ZLING=no ..

--- a/plugins/brieflz/squash-brieflz.c
+++ b/plugins/brieflz/squash-brieflz.c
@@ -28,7 +28,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <errno.h>
 #include <limits.h>
 

--- a/plugins/brotli/squash-brotli.cpp
+++ b/plugins/brotli/squash-brotli.cpp
@@ -41,11 +41,9 @@ enum SquashBrotliOptionIndex {
    least, I can't figure out how to do it), so there is some extra
    code in the init_plugin func to finish it off. */
 static SquashOptionInfo squash_brotli_options[] = {
-  { .name = (char*) "level",
-    .type = SQUASH_OPTION_TYPE_RANGE_INT },
-  { .name = (char*) "mode",
-    .type = SQUASH_OPTION_TYPE_ENUM_STRING },
-  { NULL, SQUASH_OPTION_TYPE_NONE, }
+  { "level", SQUASH_OPTION_TYPE_RANGE_INT },
+  { "mode", SQUASH_OPTION_TYPE_ENUM_STRING },
+  { NULL, SQUASH_OPTION_TYPE_NONE }
 };
 
 typedef struct SquashBrotliStream_s {
@@ -323,14 +321,14 @@ squash_plugin_init_plugin (SquashPlugin* plugin) {
   squash_brotli_options[SQUASH_BROTLI_OPT_LEVEL].default_value.int_value = 11;
   squash_brotli_options[SQUASH_BROTLI_OPT_LEVEL].info.range_int = level_range;
 
-  squash_brotli_options[SQUASH_BROTLI_OPT_MODE].default_value.int_value = brotli::BrotliParams::MODE_GENERIC;
-  squash_brotli_options[SQUASH_BROTLI_OPT_MODE].info.enum_string = {
-    (const SquashOptionInfoEnumStringMap []) {
+  static const SquashOptionInfoEnumStringMap option_strings[] = {
       { "generic", brotli::BrotliParams::MODE_GENERIC },
       { "text", brotli::BrotliParams::MODE_TEXT },
       { "font", brotli::BrotliParams::MODE_FONT },
-      { NULL, 0 } }
+      { NULL, 0 }
   };
+  squash_brotli_options[SQUASH_BROTLI_OPT_MODE].default_value.int_value = brotli::BrotliParams::MODE_GENERIC;
+  squash_brotli_options[SQUASH_BROTLI_OPT_MODE].info.enum_string.values = option_strings;
 
   return SQUASH_OK;
 }

--- a/plugins/bsc/squash-bsc.c
+++ b/plugins/bsc/squash-bsc.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <limits.h>
 
 #include <squash/squash.h>

--- a/plugins/bzip2/squash-bzip2.c
+++ b/plugins/bzip2/squash-bzip2.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include <squash/squash.h>
 

--- a/plugins/density/squash-density.c
+++ b/plugins/density/squash-density.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <errno.h>
 
 #include <squash/squash.h>

--- a/plugins/doboz/squash-doboz.cpp
+++ b/plugins/doboz/squash-doboz.cpp
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <new>
 
 #include <squash/squash.h>

--- a/plugins/fari/squash-fari.c
+++ b/plugins/fari/squash-fari.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <errno.h>
 
 #include <squash/squash.h>

--- a/plugins/fastlz/squash-fastlz.c
+++ b/plugins/fastlz/squash-fastlz.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <errno.h>
 #include <limits.h>
 

--- a/plugins/gipfeli/squash-gipfeli.cpp
+++ b/plugins/gipfeli/squash-gipfeli.cpp
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <stdexcept>
 
 #include <squash/squash.h>

--- a/plugins/heatshrink/squash-heatshrink.c
+++ b/plugins/heatshrink/squash-heatshrink.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include <squash/squash.h>
 

--- a/plugins/lz4/squash-lz4.c
+++ b/plugins/lz4/squash-lz4.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <errno.h>
 #include <limits.h>
 

--- a/plugins/lz4/squash-lz4f.c
+++ b/plugins/lz4/squash-lz4f.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <errno.h>
 
 #include <squash/squash.h>

--- a/plugins/lzf/squash-lzf.c
+++ b/plugins/lzf/squash-lzf.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <errno.h>
 
 #include <squash/squash.h>

--- a/plugins/lzg/squash-lzg.c
+++ b/plugins/lzg/squash-lzg.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include <squash/squash.h>
 

--- a/plugins/lzham/squash-lzham.c
+++ b/plugins/lzham/squash-lzham.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include <squash/squash.h>
 

--- a/plugins/lzjb/squash-lzjb.c
+++ b/plugins/lzjb/squash-lzjb.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <errno.h>
 
 #include <squash/squash.h>

--- a/plugins/lzma/squash-lzma.c
+++ b/plugins/lzma/squash-lzma.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include <squash/squash.h>
 

--- a/plugins/lzo/squash-lzo.c
+++ b/plugins/lzo/squash-lzo.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include <squash/squash.h>
 

--- a/plugins/ms-compress/squash-ms-compress.c
+++ b/plugins/ms-compress/squash-ms-compress.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <errno.h>
 
 #include <squash/squash.h>

--- a/plugins/ncompress/compress.c
+++ b/plugins/ncompress/compress.c
@@ -47,7 +47,11 @@
 #   define BYTEORDER 1234
 #  endif
 # else
-#  warning Unable to figure out byteorder, defaulting to slow byte swapping
+#  ifdef _MSC_VER
+#   pragma message("Unable to figure out byteorder, defaulting to slow byte swapping")
+#  else
+#   warning Unable to figure out byteorder, defaulting to slow byte swapping
+#  endif
 #  define BYTEORDER 0000
 # endif
 #endif

--- a/plugins/ncompress/squash-ncompress.c
+++ b/plugins/ncompress/squash-ncompress.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <errno.h>
 
 #include <squash/squash.h>

--- a/plugins/pithy/squash-pithy.c
+++ b/plugins/pithy/squash-pithy.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <errno.h>
 
 #include <squash/squash.h>

--- a/plugins/quicklz/squash-quicklz.c
+++ b/plugins/quicklz/squash-quicklz.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <errno.h>
 
 #include <squash/squash.h>

--- a/plugins/snappy/squash-snappy-framed.c
+++ b/plugins/snappy/squash-snappy-framed.c
@@ -36,7 +36,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include <squash/squash.h>
 #include <snappy-c.h>

--- a/plugins/snappy/squash-snappy.c
+++ b/plugins/snappy/squash-snappy.c
@@ -30,7 +30,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include <squash/squash.h>
 #include <snappy-c.h>

--- a/plugins/wflz/squash-wflz.c
+++ b/plugins/wflz/squash-wflz.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include <squash/squash.h>
 

--- a/plugins/yalz77/squash-yalz77.cpp
+++ b/plugins/yalz77/squash-yalz77.cpp
@@ -28,7 +28,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include <squash/squash.h>
 

--- a/plugins/zlib-ng/squash-zlib-ng.c
+++ b/plugins/zlib-ng/squash-zlib-ng.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <limits.h>
 
 #include <squash/squash.h>

--- a/plugins/zlib/squash-zlib.c
+++ b/plugins/zlib/squash-zlib.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <limits.h>
 
 #include <squash/squash.h>

--- a/plugins/zling/squash-zling.cpp
+++ b/plugins/zling/squash-zling.cpp
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 
 #include <squash/squash.h>
 

--- a/plugins/zpaq/squash-zpaq.cpp
+++ b/plugins/zpaq/squash-zpaq.cpp
@@ -27,7 +27,12 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+
+#if !defined(_MSC_VER)
 #include <strings.h>
+#else
+#define snprintf _snprintf
+#endif
 
 #include <squash/squash.h>
 

--- a/plugins/zpaq/squash-zpaq.cpp
+++ b/plugins/zpaq/squash-zpaq.cpp
@@ -31,7 +31,9 @@
 #if !defined(_MSC_VER)
 #include <strings.h>
 #else
-#define snprintf _snprintf
+#if _MSC_VER < 1900 
+#define snprintf _snprintf 
+#endif
 #endif
 
 #include <squash/squash.h>

--- a/plugins/zstd/squash-zstd.c
+++ b/plugins/zstd/squash-zstd.c
@@ -27,7 +27,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <errno.h>
 
 #include <squash/squash.h>

--- a/squash/codec.c
+++ b/squash/codec.c
@@ -30,10 +30,13 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <stdio.h>
-#include <strings.h>
 
+#if !defined(_MSC_VER)
+#include <unistd.h>
+#include <strings.h>
+#endif
+ 
 #if !defined(_WIN32)
 #include <sys/mman.h>
 #endif

--- a/squash/context.c
+++ b/squash/context.c
@@ -35,11 +35,14 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <string.h>
-#include <unistd.h>
 #include <stddef.h>
 #include <ctype.h>
 #include <stdio.h>
+
+#if !defined(_MSC_VER)
+#include <unistd.h>
 #include <strings.h>
+#endif
 
 #if !defined(_WIN32)
   #include <dirent.h>

--- a/squash/file.c
+++ b/squash/file.c
@@ -34,7 +34,10 @@
 
 #include <sys/stat.h>
 #include <string.h>
+
+#if !defined(_MSC_VER)
 #include <unistd.h>
+#endif
 
 /* #define SQUASH_MMAP_IO */
 

--- a/squash/internal.h
+++ b/squash/internal.h
@@ -81,8 +81,10 @@
 
 #if defined(_MSC_VER)
 #define strcasecmp _stricmp
-#define snprintf _snprintf
 #define strtok_r strtok_s
+#if _MSC_VER < 1900 
+#define snprintf _snprintf 
+#endif
 #endif
 
 #endif /* SQUASH_INTERNAL_H */

--- a/squash/internal.h
+++ b/squash/internal.h
@@ -79,4 +79,10 @@
 #  include "mapped-file-internal.h"
 #endif
 
+#if defined(_MSC_VER)
+#define strcasecmp _stricmp
+#define snprintf _snprintf
+#define strtok_r strtok_s
+#endif
+
 #endif /* SQUASH_INTERNAL_H */

--- a/squash/license.c
+++ b/squash/license.c
@@ -26,7 +26,11 @@
 
 #include "internal.h"
 
+#include <string.h>
+
+#if !defined(_MSC_VER)
 #include <strings.h>
+#endif
 
 /**
  * @def SQUASH_LICENSE_UNKNOWN

--- a/squash/options.c
+++ b/squash/options.c
@@ -28,8 +28,11 @@
 #define _POSIX_C_SOURCE 200809L
 
 #include <assert.h>
-#include <strings.h>
 #include <string.h>
+
+#if !defined(_MSC_VER)
+#include <strings.h>
+#endif
 
 #include "internal.h"
 

--- a/squash/plugin.c
+++ b/squash/plugin.c
@@ -154,7 +154,7 @@ squash_plugin_init (SquashPlugin* plugin) {
 #if !defined(_WIN32)
       *(void **) (&init_func) = dlsym (plugin->plugin, "squash_plugin_init_plugin");
 #else
-      *(void **) (&init_func) = GetProcAddress (handle, "squash_plugin_init_plugin");
+      *(void **) (&init_func) = GetProcAddress (plugin->plugin, "squash_plugin_init_plugin");
 #endif
       if (init_func != NULL) {
         init_func (plugin);

--- a/squash/plugin.c
+++ b/squash/plugin.c
@@ -116,8 +116,13 @@ squash_plugin_init (SquashPlugin* plugin) {
     plugin_file_name_max_size = plugin_dir_size + squash_version_api_size + plugin_name_size + 19 + strlen (SQUASH_SHARED_LIBRARY_SUFFIX);
     plugin_file_name = (char*) malloc (plugin_file_name_max_size + 1);
 
+#if defined(_MSC_VER)
+    snprintf (plugin_file_name, plugin_file_name_max_size + 1,
+              "%s/squash%s-plugin-%s%s", plugin->directory, SQUASH_VERSION_API, plugin->name, SQUASH_SHARED_LIBRARY_SUFFIX);
+#else
     snprintf (plugin_file_name, plugin_file_name_max_size + 1,
               "%s/libsquash%s-plugin-%s%s", plugin->directory, SQUASH_VERSION_API, plugin->name, SQUASH_SHARED_LIBRARY_SUFFIX);
+#endif
 
 #if !defined(_WIN32)
     handle = dlopen (plugin_file_name, RTLD_LAZY);

--- a/squash/slist-internal.h
+++ b/squash/slist-internal.h
@@ -34,6 +34,14 @@
 
 #include <stdlib.h>
 
+#if defined(_MSC_VER)
+#define inline __inline
+#endif
+
+#if defined(_MSC_VER)
+#define inline __inline
+#endif
+
 SQUASH_BEGIN_DECLS
 
 typedef struct _SquashSList {

--- a/squash/slist-internal.h
+++ b/squash/slist-internal.h
@@ -38,10 +38,6 @@
 #define inline __inline
 #endif
 
-#if defined(_MSC_VER)
-#define inline __inline
-#endif
-
 SQUASH_BEGIN_DECLS
 
 typedef struct _SquashSList {

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable (squash squash.c)
+add_executable (squash squash.c parg.c)
 target_add_extra_warning_flags (squash)
 target_link_libraries (squash squash${SQUASH_VERSION_API})
 

--- a/utils/parg.c
+++ b/utils/parg.c
@@ -1,0 +1,286 @@
+/*
+ * parg - parse argv
+ *
+ * Written in 2015 by Joergen Ibsen
+ *
+ * To the extent possible under law, the author(s) have dedicated all
+ * copyright and related and neighboring rights to this software to the
+ * public domain worldwide. This software is distributed without any
+ * warranty. <http://creativecommons.org/publicdomain/zero/1.0/>
+ */
+
+#include "parg.h"
+
+#include <assert.h>
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Check if state is at end of argv.
+ */
+static int
+is_argv_end(const struct parg_state *ps, int argc, char *const argv[])
+{
+	return ps->optind >= argc || argv[ps->optind] == NULL;
+}
+
+/*
+ * Match nextchar against optstring.
+ */
+static int
+match_short(struct parg_state *ps, int argc, char *const argv[],
+            const char *optstring)
+{
+	const char *p = strchr(optstring, *ps->nextchar);
+
+	if (p == NULL) {
+		ps->optopt = *ps->nextchar++;
+		return '?';
+	}
+
+	/* If no option argument, return option */
+	if (p[1] != ':') {
+		return *ps->nextchar++;
+	}
+
+	/* If more characters, return as option argument */
+	if (ps->nextchar[1] != '\0') {
+		ps->optarg = &ps->nextchar[1];
+		ps->nextchar = NULL;
+		return *p;
+	}
+
+	/* If option argument is optional, return option */
+	if (p[2] == ':') {
+		return *ps->nextchar++;
+	}
+
+	/* Option argument required, so return next argv element */
+	if (is_argv_end(ps, argc, argv)) {
+		ps->optopt = *ps->nextchar++;
+		return optstring[0] == ':' ? ':' : '?';
+	}
+
+	ps->optarg = argv[ps->optind++];
+	ps->nextchar = NULL;
+	return *p;
+}
+
+/*
+ * Match string at nextchar against longopts.
+ */
+static int
+match_long(struct parg_state *ps, int argc, char *const argv[],
+           const char *optstring,
+           const struct parg_option *longopts, int *longindex)
+{
+	size_t len;
+	int num_match = 0;
+	int match = -1;
+	int i;
+
+	len = strcspn(ps->nextchar, "=");
+
+	for (i = 0; longopts[i].name; ++i) {
+		if (strncmp(ps->nextchar, longopts[i].name, len) == 0) {
+			match = i;
+			num_match++;
+			/* Take if exact match */
+			if (longopts[i].name[len] == '\0') {
+				num_match = 1;
+				break;
+			}
+		}
+	}
+
+	/* Return '?' on no or ambiguous match */
+	if (num_match != 1) {
+		ps->nextchar = NULL;
+		return '?';
+	}
+
+	assert(match != -1);
+
+	if (longindex) {
+		*longindex = match;
+	}
+
+	if (ps->nextchar[len] == '=') {
+		/* Option argument present, check if extraneous */
+		if (longopts[match].has_arg == PARG_NOARG) {
+			ps->optopt = longopts[match].flag ? 0 : longopts[match].val;
+			ps->nextchar = NULL;
+			return optstring[0] == ':' ? ':' : '?';
+		}
+		else {
+			ps->optarg = &ps->nextchar[len + 1];
+		}
+	}
+	else if (longopts[match].has_arg == PARG_REQARG) {
+		/* Option argument required, so return next argv element */
+		if (is_argv_end(ps, argc, argv)) {
+			ps->optopt = longopts[match].flag ? 0 : longopts[match].val;
+			ps->nextchar = NULL;
+			return optstring[0] == ':' ? ':' : '?';
+		}
+
+		ps->optarg = argv[ps->optind++];
+	}
+
+	ps->nextchar = NULL;
+
+	if (longopts[match].flag != NULL) {
+		*longopts[match].flag = longopts[match].val;
+		return 0;
+	}
+
+	return longopts[match].val;
+}
+
+void
+parg_init(struct parg_state *ps)
+{
+	ps->optarg = NULL;
+	ps->optind = 1;
+	ps->optopt = '?';
+	ps->nextchar = NULL;
+}
+
+int
+parg_getopt(struct parg_state *ps, int argc, char *const argv[],
+            const char *optstring)
+{
+	return parg_getopt_long(ps, argc, argv, optstring, NULL, NULL);
+}
+
+int
+parg_getopt_long(struct parg_state *ps, int argc, char *const argv[],
+                 const char *optstring,
+                 const struct parg_option *longopts, int *longindex)
+{
+	assert(ps != NULL);
+	assert(argv != NULL);
+	assert(optstring != NULL);
+
+	ps->optarg = NULL;
+
+	if (argc < 2) {
+		return -1;
+	}
+
+	/* Advance to next element if needed */
+	if (ps->nextchar == NULL || *ps->nextchar == '\0') {
+		if (is_argv_end(ps, argc, argv)) {
+			return -1;
+		}
+
+		ps->nextchar = argv[ps->optind++];
+
+		/* Check for nonoption element (including '-') */
+		if (ps->nextchar[0] != '-' || ps->nextchar[1] == '\0') {
+			ps->optarg = ps->nextchar;
+			ps->nextchar = NULL;
+			return 1;
+		}
+
+		/* Check for '--' */
+		if (ps->nextchar[1] == '-') {
+			if (ps->nextchar[2] == '\0') {
+				return -1;
+			}
+
+			if (longopts != NULL) {
+				ps->nextchar += 2;
+
+				return match_long(ps, argc, argv, optstring,
+				                  longopts, longindex);
+			}
+		}
+
+		ps->nextchar++;
+	}
+
+	/* Match nextchar */
+	return match_short(ps, argc, argv, optstring);
+}
+
+int
+parg_reorder(int argc, char *argv[],
+             const char *optstring,
+             const struct parg_option *longopts)
+{
+	struct parg_state ps;
+	char **new_argv = NULL;
+	int start = 1;
+	int end = argc;
+	int curind;
+	int i;
+
+	assert(argv != NULL);
+	assert(optstring != NULL);
+
+	if (argc < 2) {
+		return argc;
+	}
+
+	new_argv = calloc((size_t) argc, sizeof(argv[0]));
+
+	if (new_argv == NULL) {
+		return -1;
+	}
+
+	new_argv[0] = argv[0];
+
+	parg_init(&ps);
+
+	for (;;) {
+		int c;
+
+		curind = ps.optind;
+
+		c = parg_getopt_long(&ps, argc, argv, optstring, longopts, NULL);
+
+		if (c == -1) {
+			break;
+		}
+		else if (c == 1) {
+			assert(ps.optind - curind == 1);
+
+			/* Add nonoption to end of new_argv */
+			new_argv[--end] = (char *) ps.optarg;
+		}
+		else {
+			/* Add option with any argument to start of new_argv */
+			while (curind < ps.optind) {
+				new_argv[start++] = argv[curind++];
+			}
+		}
+	}
+
+	if (end > start) {
+		assert(strcmp(argv[curind], "--") == 0);
+
+		/* Copy '--' element */
+		new_argv[start++] = argv[curind++];
+
+		/* Copy remaining nonoptions to end of new_argv */
+		for (i = curind; end > start; ++i) {
+			new_argv[--end] = argv[i];
+		}
+	}
+
+	/* Copy options back to argv */
+	for (i = 1; i < end; ++i) {
+		argv[i] = new_argv[i];
+	}
+
+	/* Copy nonoptions in reverse order to argv */
+	for (; i < argc; ++i) {
+		argv[i] = new_argv[argc - i + end - 1];
+	}
+
+	free(new_argv);
+
+	return end;
+}

--- a/utils/parg.h
+++ b/utils/parg.h
@@ -1,0 +1,192 @@
+/*
+ * parg - parse argv
+ *
+ * Written in 2015 by Joergen Ibsen
+ *
+ * To the extent possible under law, the author(s) have dedicated all
+ * copyright and related and neighboring rights to this software to the
+ * public domain worldwide. This software is distributed without any
+ * warranty. <http://creativecommons.org/publicdomain/zero/1.0/>
+ */
+
+#ifndef PARG_H_INCLUDED
+#define PARG_H_INCLUDED
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define PARG_VER_MAJOR 1        /**< Major version number */
+#define PARG_VER_MINOR 0        /**< Minor version number */
+#define PARG_VER_PATCH 0        /**< Patch version number */
+#define PARG_VER_STRING "1.0.0" /**< Version number as a string */
+
+/**
+ * Structure containing state between calls to parser.
+ *
+ * @see parg_init
+ */
+struct parg_state {
+	const char *optarg;   /**< Pointer to option argument, if any */
+	int optind;           /**< Next index in argv to process */
+	int optopt;           /**< Option value resulting in error, if any */
+	const char *nextchar; /**< Next character to process */
+};
+
+/**
+ * Structure for supplying long options to `parg_getopt_long()`.
+ *
+ * @see parg_getopt_long
+ */
+struct parg_option {
+	const char *name; /**< Name of option */
+	int has_arg;      /**< Option argument status */
+	int *flag;        /**< Pointer to flag variable */
+	int val;          /**< Value of option */
+};
+
+/**
+ * Values for the `has_arg` flag in `parg_option`.
+ *
+ * @see parg_option
+ */
+typedef enum {
+	PARG_NOARG,  /**< No argument */
+	PARG_REQARG, /**< Required argument */
+	PARG_OPTARG  /**< Optional argument */
+} parg_arg_num;
+
+/**
+ * Initialize `ps`.
+ *
+ * Must be called before using state with a parser.
+ *
+ * @see parg_state
+ *
+ * @param ps pointer to state
+ */
+void
+parg_init(struct parg_state *ps);
+
+/**
+ * Parse next short option in `argv`.
+ *
+ * Elements in `argv` that contain short options start with a single dash
+ * followed by one or more option characters, and optionally an option
+ * argument for the last option character. Examples are '`-d`', '`-ofile`',
+ * and '`-dofile`'.
+ *
+ * Consecutive calls to this function match the command-line arguments in
+ * `argv` against the short option characters in `optstring`.
+ *
+ * If an option character in `optstring` is followed by a colon, '`:`', the
+ * option requires an argument. If it is followed by two colons, the option
+ * may take an optional argument.
+ *
+ * If a match is found, `optarg` points to the option argument, if any, and
+ * the value of the option character is returned.
+ *
+ * If a match is found, but is missing a required option argument, `optopt`
+ * is set to the option character. If the first character in `optstring` is
+ * '`:`', then '`:`' is returned, otherwise '`?`' is returned.
+ *
+ * If no option character in `optstring` matches a short option, `optopt`
+ * is set to the option character, and '`?`' is returned.
+ *
+ * If an elements of argv does not contain options (a nonoption element),
+ * `optarg` points to the element, and `1` is returned.
+ *
+ * An element consisting of a single dash, '`-`', is returned as a nonoption.
+ *
+ * Parsing stops and `-1` is returned, when the end of `argv` is reached, or
+ * if an element contains '`--`'.
+ *
+ * Works similarly to `getopt`, if `optstring` were prefixed by '`-`'.
+ *
+ * @param ps pointer to state
+ * @param argc number of elements in `argv`
+ * @param argv array of pointers to command-line arguments
+ * @param optstring string containing option characters
+ * @return option value on match, `1` on nonoption element, `-1` on end of
+ * arguments, '`?`' on unmatched option, '`?`' or '`:`' on option argument
+ * error
+ */
+int
+parg_getopt(struct parg_state *ps, int argc, char *const argv[],
+            const char *optstring);
+
+/**
+ * Parse next long or short option in `argv`.
+ *
+ * Elements in `argv` that contain a long option start with two dashes
+ * followed by a string, and optionally an equal sign and an option argument.
+ * Examples are '`--help`' and '`--size=5`'.
+ *
+ * If no exact match is found, an unambiguous prefix of a long option will
+ * match. For example, if '`foo`' and '`foobar`' are valid long options, then
+ * '`--fo`' is ambiguous and will not match, '`--foo`' matches exactly, and
+ * '`--foob`' is an unambiguous prefix and will match.
+ *
+ * If a long option match is found, and `flag` is `NULL`, `val` is returned.
+ *
+ * If a long option match is found, and `flag` is not `NULL`, `val` is stored
+ * in the variable `flag` points to, and `0` is returned.
+ *
+ * If a long option match is found, but is missing a required option argument,
+ * or has an option argument even though it takes none, `optopt` is set to
+ * `val` if `flag` is `NULL`, and `0` otherwise. If the first character in
+ * `optstring` is '`:`', then '`:`' is returned, otherwise '`?`' is returned.
+ *
+ * If `longindex` is not `NULL`, the index of the entry in `longopts` that
+ * matched is stored there.
+ *
+ * If no long option in `longopts` matches a long option, '`?`' is returned.
+ *
+ * Handling of nonoptions and short options is like `parg_getopt()`.
+ *
+ * If no short options are required, an empty string, `""`, should be passed
+ * as `optstring`.
+ *
+ * Works similarly to `getopt_long`, if `optstring` were prefixed by '`-`'.
+ *
+ * @see parg_getopt
+ *
+ * @param ps pointer to state
+ * @param argc number of elements in `argv`
+ * @param argv array of pointers to command-line arguments
+ * @param optstring string containing option characters
+ * @param longopts array of `parg_option` structures
+ * @param longindex pointer to variable to store index of matching option in
+ * @return option value on match, `0` for flag option, `1` on nonoption
+ * element, `-1` on end of arguments, '`?`' on unmatched or ambiguous option,
+ * '`?`' or '`:`' on option argument error
+ */
+int
+parg_getopt_long(struct parg_state *ps, int argc, char *const argv[],
+                 const char *optstring,
+                 const struct parg_option *longopts, int *longindex);
+
+/**
+ * Reorder elements of `argv` so options appear first.
+ *
+ * If there are no long options, `longopts` may be `NULL`.
+ *
+ * @note The current implementation does not permute `argv` in place, it
+ * allocates a temporary array the same size as `argv`.
+ *
+ * @param argc number of elements in `argv`
+ * @param argv array of pointers to command-line arguments
+ * @param optstring string containing option characters
+ * @param longopts array of `parg_option` structures
+ * @return index of first nonoption in `argv` on success, `-1` on error
+ */
+int
+parg_reorder(int argc, char *argv[],
+             const char *optstring,
+             const struct parg_option *longopts);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* PARG_H_INCLUDED */

--- a/utils/squash.c
+++ b/utils/squash.c
@@ -351,14 +351,16 @@ int main (int argc, char** argv) {
   }
 
   if ( !keep && input != stdin ) {
+    fclose (input);
     if ( unlink (input_name) != 0 ) {
       perror ("Unable to remove input file");
     }
+    input = NULL;
   }
 
  cleanup:
 
-  if (input != stdin)
+  if (input != stdin && input != NULL)
     fclose (stdin);
 
   if (output != stdout)

--- a/utils/squash.c
+++ b/utils/squash.c
@@ -310,11 +310,10 @@ int main (int argc, char** argv) {
   } else {
     int output_fd = open (output_name,
                           O_RDWR | O_CREAT | (force ? O_TRUNC : O_EXCL),
-                          S_IRUSR | S_IWUSR
 #if !defined(_WIN32)
-                          | S_IRGRP | S_IROTH
+                          S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH
 #else
-                          | O_BINARY
+                          O_BINARY
 #endif
 );
     if ( output_fd < 0 ) {

--- a/utils/squash.c
+++ b/utils/squash.c
@@ -317,13 +317,14 @@ int main (int argc, char** argv) {
     output = stdout;
   } else {
     int output_fd = open (output_name,
-                          O_RDWR | O_CREAT | (force ? O_TRUNC : O_EXCL),
 #if !defined(_WIN32)
+                          O_RDWR | O_CREAT | (force ? O_TRUNC : O_EXCL),
                           S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH
 #else
-                          O_BINARY
+                          O_RDWR | O_CREAT | (force ? O_TRUNC : O_EXCL) | O_BINARY,
+                          S_IREAD | S_IWRITE
 #endif
-);
+    );
     if ( output_fd < 0 ) {
       perror ("Unable to open output file");
       retval = EXIT_FAILURE;

--- a/utils/squash.c
+++ b/utils/squash.c
@@ -1,12 +1,18 @@
-#include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
 #include <stdbool.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+
+#if !defined(_MSC_VER)
+#include <unistd.h>
+#include <strings.h>
+#else
+#define strcasecmp _stricmp
+#define snprintf _snprintf
+#endif
 
 #if !defined(EXIT_SUCCESS)
 #define EXIT_SUCCESS (0)


### PR DESCRIPTION
As discussed in #86.

The goal so far is just to get it to compile and run, here are some notes:

  - Most of the plugins included strings.h, but only zpaq appeared to use it. I removed it, and added a define to zpaq to use the equivalent MSVC function.
  - I put defines to map functions from strings.h to MSVC functions into internal.h
  - MSVC does not come with getopt, I don't know if you would prefer to include a getopt port, or write your own command line handling. For starters I used a getopt-like parser I wrote a while back called parg.
  - The following plugins did not compile out of the box: gipfeli, brotli, density, pithy, snappy, zling, and zstd.
