### PR TITLE
Fix include file order

### DIFF
--- a/squash/context.c
+++ b/squash/context.c
@@ -46,8 +46,8 @@
 #if !defined(_WIN32)
   #include <dirent.h>
 #else
-  #include <strsafe.h>
   #include <tchar.h>
+  #include <strsafe.h>
   #include <windows.h>
 #endif
 


### PR DESCRIPTION
MSVC 2013 required strsafe.h to be included after tchar.h.