### PR TITLE
Fix heatshrink plugin when splicing

### DIFF
--- a/plugins/heatshrink/squash-heatshrink.c
+++ b/plugins/heatshrink/squash-heatshrink.c
@@ -160,7 +160,7 @@ squash_heatshrink_process_stream (SquashStream* stream, SquashOperation operatio
       stream->avail_out -= processed;
     }
 
-    if (HSER_POLL_MORE == hsp) {
+    if (HSER_POLL_MORE == hsp || 0 == stream->avail_out) {
       return SQUASH_PROCESSING;
     } else if (SQUASH_OPERATION_FINISH == operation) {
       HSE_finish_res hsf = heatshrink_encoder_finish (s->ctx.comp);


### PR DESCRIPTION
If the first call to `heatshrink_encoder_poll()` fills the output buffer, the second call fails.

