### PR TITLE
Change sizes to malloc() to size_t

### DIFF
--- a/squash/file.c
+++ b/squash/file.c
@@ -575,7 +575,7 @@ squash_file_printf (SquashFile* file,
                     ...) {
   SquashStatus res = SQUASH_OK;
   va_list ap;
-  int size;
+  size_t size;
   char buf[256];
   char* heap_buf = NULL;
 


### PR DESCRIPTION
Regardless of the target platform, all size arguments to `malloc()` should be of type `size_t`. This helps to ensure the proper register word size on any given architecture.