### PR TITLE
Update the brotli submodule to its latest version.

### DIFF
--- a/plugins/brotli/CMakeLists.txt
+++ b/plugins/brotli/CMakeLists.txt
@@ -24,6 +24,8 @@ squash_plugin (
     brotli/enc/backward_references.cc
     brotli/enc/block_splitter.cc
     brotli/enc/brotli_bit_stream.cc
+    brotli/enc/compress_fragment.cc
+    brotli/enc/compress_fragment_two_pass.cc
     brotli/enc/dictionary.cc
     brotli/enc/encode.cc
     brotli/enc/encode_parallel.cc


### PR DESCRIPTION
The brotli encoder got a new faster compression mode,
quality 0, which is about 2x faster than the fastest
mode in the previous version, and the quality 1 mode
also got considerably faster.

Because of this, it might be worth re-running the brotli
benchmarks and updating the benchmark results.