### PR TITLE
Typed option funcs

### DIFF
--- a/squash/options.c
+++ b/squash/options.c
@@ -156,7 +156,7 @@
  * @brief value to use if none is provided by the user
  */
 
-static ssize_t
+static ptrdiff_t
 squash_options_find (SquashOptions* options, const char* key) {
   assert (options != NULL);
   assert (key != NULL);
@@ -165,7 +165,7 @@ squash_options_find (SquashOptions* options, const char* key) {
   if (info == NULL)
     return -1;
 
-  ssize_t option_n = 0;
+  ptrdiff_t option_n = 0;
 
   {
     while (info->name != NULL) {
@@ -195,7 +195,7 @@ squash_options_get_string (SquashOptions* options, const char* key) {
   if (options == NULL)
     return NULL;
 
-  const ssize_t option_n = squash_options_find (options, key);
+  const ptrdiff_t option_n = squash_options_find (options, key);
   if (option_n < 0)
     return NULL;
 
@@ -214,7 +214,7 @@ squash_options_get_bool (SquashOptions* options, const char* key) {
   if (options == NULL)
     return false;
 
-  const ssize_t option_n = squash_options_find (options, key);
+  const ptrdiff_t option_n = squash_options_find (options, key);
   if (option_n < 0)
     return false;
 
@@ -233,7 +233,7 @@ squash_options_get_int (SquashOptions* options, const char* key) {
   if (options == NULL)
     return -1;
 
-  const ssize_t option_n = squash_options_find (options, key);
+  const ptrdiff_t option_n = squash_options_find (options, key);
   if (option_n < 0)
     return -1;
 
@@ -252,7 +252,7 @@ squash_options_get_size (SquashOptions* options, const char* key) {
   if (options == NULL)
     return 0;
 
-  const ssize_t option_n = squash_options_find (options, key);
+  const ptrdiff_t option_n = squash_options_find (options, key);
   if (option_n < 0)
     return 0;
 
@@ -412,7 +412,7 @@ squash_options_set_string (SquashOptions* options, const char* key, const char* 
   assert (key != NULL);
   assert (value != NULL);
 
-  const ssize_t option_n = squash_options_find (options, key);
+  const ptrdiff_t option_n = squash_options_find (options, key);
   if (option_n < 0)
     return squash_error (SQUASH_BAD_PARAM);
 
@@ -434,7 +434,7 @@ squash_options_set_bool (SquashOptions* options, const char* key, bool value) {
   assert (options != NULL);
   assert (key != NULL);
 
-  const ssize_t option_n = squash_options_find (options, key);
+  const ptrdiff_t option_n = squash_options_find (options, key);
   if (option_n < 0)
     return squash_error (SQUASH_BAD_PARAM);
   
@@ -457,7 +457,7 @@ squash_options_set_int (SquashOptions* options, const char* key, int value) {
   assert (options != NULL);
   assert (key != NULL);
 
-  const ssize_t option_n = squash_options_find (options, key);
+  const ptrdiff_t option_n = squash_options_find (options, key);
   if (option_n < 0)
     return squash_error (SQUASH_BAD_PARAM);
 
@@ -480,7 +480,7 @@ squash_options_set_size (SquashOptions* options, const char* key, size_t value) 
   assert (options != NULL);
   assert (key != NULL);
 
-  const ssize_t option_n = squash_options_find (options, key);
+  const ptrdiff_t option_n = squash_options_find (options, key);
   if (option_n < 0)
     return squash_error (SQUASH_BAD_PARAM);
 
@@ -516,7 +516,7 @@ squash_options_set_string_at (SquashOptions* options, size_t index, const char* 
       val->string_value = strdup (value);
       return SQUASH_OK;
     case SQUASH_OPTION_TYPE_ENUM_STRING:
-      for (ssize_t i = 0 ; info->info.enum_string.values[i].name != NULL ; i++) {
+      for (ptrdiff_t i = 0 ; info->info.enum_string.values[i].name != NULL ; i++) {
         if (strcasecmp (value, info->info.enum_string.values[i].name) == 0) {
           val->int_value = info->info.enum_string.values[i].value;
           return SQUASH_OK;
@@ -668,7 +668,7 @@ squash_options_parse_option (SquashOptions* options, const char* key, const char
   assert (value != NULL);
   assert (options->codec != NULL);
 
-  const ssize_t option_n = squash_options_find (options, key);
+  const ptrdiff_t option_n = squash_options_find (options, key);
   if (option_n < 0)
     return squash_error (SQUASH_BAD_PARAM);
 

--- a/squash/options.h
+++ b/squash/options.h
@@ -147,6 +147,15 @@ SQUASH_API SquashStatus   squash_options_set_int       (SquashOptions* options, 
 SQUASH_NONNULL(1, 2)
 SQUASH_API SquashStatus   squash_options_set_size      (SquashOptions* options, const char* key, size_t value);
 
+SQUASH_NONNULL(1, 3)
+SQUASH_API SquashStatus   squash_options_set_string_at (SquashOptions* options, size_t index, const char* value);
+SQUASH_NONNULL(1)
+SQUASH_API SquashStatus   squash_options_set_bool_at   (SquashOptions* options, size_t index, bool value);
+SQUASH_NONNULL(1)
+SQUASH_API SquashStatus   squash_options_set_int_at    (SquashOptions* options, size_t index, int value);
+SQUASH_NONNULL(1)
+SQUASH_API SquashStatus   squash_options_set_size_at   (SquashOptions* options, size_t index, size_t value);
+
 SQUASH_SENTINEL
 SQUASH_NONNULL(1)
 SQUASH_API SquashStatus   squash_options_parse         (SquashOptions* options, ...);

--- a/squash/options.h
+++ b/squash/options.h
@@ -133,6 +133,11 @@ SQUASH_API int            squash_options_get_int       (SquashOptions* options, 
 SQUASH_NONNULL(2)
 SQUASH_API size_t         squash_options_get_size      (SquashOptions* options, const char* key);
 
+SQUASH_API const char*    squash_options_get_string_at (SquashOptions* options, size_t index);
+SQUASH_API bool           squash_options_get_bool_at   (SquashOptions* options, size_t index);
+SQUASH_API int            squash_options_get_int_at    (SquashOptions* options, size_t index);
+SQUASH_API size_t         squash_options_get_size_at   (SquashOptions* options, size_t index);
+
 SQUASH_SENTINEL
 SQUASH_NONNULL(1)
 SQUASH_API SquashStatus   squash_options_parse         (SquashOptions* options, ...);

--- a/squash/options.h
+++ b/squash/options.h
@@ -138,6 +138,15 @@ SQUASH_API bool           squash_options_get_bool_at   (SquashOptions* options, 
 SQUASH_API int            squash_options_get_int_at    (SquashOptions* options, size_t index);
 SQUASH_API size_t         squash_options_get_size_at   (SquashOptions* options, size_t index);
 
+SQUASH_NONNULL(1, 2, 3)
+SQUASH_API SquashStatus   squash_options_set_string    (SquashOptions* options, const char* key, const char* value);
+SQUASH_NONNULL(1, 2)
+SQUASH_API SquashStatus   squash_options_set_bool      (SquashOptions* options, const char* key, bool value);
+SQUASH_NONNULL(1, 2)
+SQUASH_API SquashStatus   squash_options_set_int       (SquashOptions* options, const char* key, int value);
+SQUASH_NONNULL(1, 2)
+SQUASH_API SquashStatus   squash_options_set_size      (SquashOptions* options, const char* key, size_t value);
+
 SQUASH_SENTINEL
 SQUASH_NONNULL(1)
 SQUASH_API SquashStatus   squash_options_parse         (SquashOptions* options, ...);


### PR DESCRIPTION
This adds the following functions related to options:
### squash_options_get_*_at (SquashOptions *options, size_t index)
 
These functions are used to get the `i`th option in the passed Options

### squash_options_set_* (SquashOptions *options, const char *key, {type} value)

These functions allow setting options in a typed way (as opposed to squash_options_parse_option, which has to parse)

### squash_options_set_*_at (SquashOptions *options, size_t index, {type} value)

Thes functions allow setting options in a typed way, based on an index, instead of a string key.