### PR TITLE
[ZSTD] Correct Max Compression Level to 22

### DIFF
--- a/plugins/zstd/squash-zstd.c
+++ b/plugins/zstd/squash-zstd.c
@@ -47,7 +47,7 @@ static SquashOptionInfo squash_zstd_options[] = {
     SQUASH_OPTION_TYPE_RANGE_INT,
     .info.range_int = {
       .min = 1,
-      .max = 21 },
+      .max = 22 },
     .default_value.int_value = 9 },
   { NULL, SQUASH_OPTION_TYPE_NONE, }
 };

--- a/plugins/zstd/zstd.md
+++ b/plugins/zstd/zstd.md
@@ -13,7 +13,7 @@ https://github.com/Cyan4973/zstd
 
 ### Compression-only ###
 
-- **level** — (integer, 1-20, default 9): compression level.  Higher
+- **level** — (integer, 1-22, default 9): compression level.  Higher
   levels compress slower, but yield a better compression ratio.
 
 ## License ##


### PR DESCRIPTION
ZSTD 0.6.1 (@47222ea) supports 22 compression levels.

Question: For the last 3 compression levels (20-22) there exists the '--ultra' commanding parameter to use more RAM for additional compression ratio, is this currently supported?