### PR TITLE
Add Visual Studio 2017 to AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,10 +3,14 @@ version: "{build}"
 environment:
   matrix:
   # MSVC
+  - GENERATOR: Visual Studio 15 2017
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  - GENERATOR: Visual Studio 15 2017 Win64
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
   - GENERATOR: Visual Studio 14 2015
   - GENERATOR: Visual Studio 14 2015 Win64
-  - GENERATOR: Visual Studio 12 2013
-  - GENERATOR: Visual Studio 12 2013 Win64
+  # - GENERATOR: Visual Studio 12 2013
+  # - GENERATOR: Visual Studio 12 2013 Win64
 
   # Mingw-w64
   - GENERATOR: MinGW Makefiles


### PR DESCRIPTION
It looks like squash builds with VS 2017 on AppVeyor now, the only change needed was to select a specific build image with the new compiler on. A few things to decide before adding this:

For now I commented out VS 2013, do we wish to continue having it in the build matrix? On one hand it's getting old, and fewer configurations means faster CI runs, on the other hand some things might break on older compilers moving forward. What do you think?

Also, as mentioned in #185, Clang/C2 appears to be dead, so perhaps we should remove the commented out section for it?