### PR TITLE
Set the RPATH of the installed squash executable

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,3 +1,6 @@
+set (CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}")
+set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 add_executable (squash squash.c parg/parg.c)
 target_add_extra_warning_flags (squash)
 target_link_libraries (squash squash${SQUASH_VERSION_API})


### PR DESCRIPTION
The RPATH of the installed squash executable must be set to the
install library directory, otherwise the installed squash executable
cannot find the libsquash library when it is executed.